### PR TITLE
Changed HPS to Reef groups in PathPlanner from Parallel to Deadline. …

### DIFF
--- a/comp/src/main/deploy/pathplanner/autos/Right Side 3 Piece RED E & C & D.auto
+++ b/comp/src/main/deploy/pathplanner/autos/Right Side 3 Piece RED E & C & D.auto
@@ -48,19 +48,19 @@
           }
         },
         {
-          "type": "parallel",
+          "type": "deadline",
           "data": {
             "commands": [
-              {
-                "type": "named",
-                "data": {
-                  "name": "Run Intake"
-                }
-              },
               {
                 "type": "path",
                 "data": {
                   "pathName": "HP to CD Right"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Run Intake"
                 }
               }
             ]
@@ -110,19 +110,19 @@
           }
         },
         {
-          "type": "parallel",
+          "type": "deadline",
           "data": {
             "commands": [
-              {
-                "type": "named",
-                "data": {
-                  "name": "Run Intake"
-                }
-              },
               {
                 "type": "path",
                 "data": {
                   "pathName": "HP to CD Left"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Run Intake"
                 }
               }
             ]


### PR DESCRIPTION
…If no coral is detected after the trajectory, the robot immediately returns to HPS.